### PR TITLE
Add 'web' image to docker compose network.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_RUN = docker run ${DOCKER_FLAGS} -t --rm \
 	--user=${HOST_UID}:${HOST_GID} \
 	--workdir=/data \
 	-v ${CURRENT_DIR}:/data \
-	node:16.13
+	node:16.13-bullseye
 
 .PHONY: all
 all: docker_build build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,20 @@ services:
     volumes:
       - ./:/data
 
+  web:
+    image: campaign-companion-frontend
+    working_dir: /data
+    depends_on:
+      - api
+    ports:
+      - 3000:3000
+    environment:
+      PORT: 3000
+    command:
+      - npm 
+      - start
+    volumes:
+      - ../campaign-companion-frontend/:/data
 
 volumes:
   dbdata1:


### PR DESCRIPTION
This ties the frontend and backend projects together. They'll need to be run from the same directory so the docker-compose network can find the frontend code. Make sure they're both checked out, run `make` in the `campaign-companion-frontend` project, come back to this directory and run `docker-compose  up`. The frontend will be running at http://localhost:3000/ and the backend running at http://localhost:7890/ .